### PR TITLE
Use relative paths. Correct casting for long double in tester.

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1,4 +1,4 @@
-#include "call.h"
+#include "../include/call.h"
 #include <stdint.h>
 
 void call(void* fptr, char *fstring, ...)

--- a/src/loader.c
+++ b/src/loader.c
@@ -1,4 +1,4 @@
-#include "loader.h"
+#include "../include/loader.h"
 
 void *load_object(const char *path)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -5,8 +5,8 @@
 #include <sys/types.h>
 #include <stdint.h>
 
-#include "call.h"
-#include "loader.h"
+#include "../include/call.h"
+#include "../include/loader.h"
 
 int main(int argc, char **argv)
 {

--- a/test/main.c
+++ b/test/main.c
@@ -1,7 +1,7 @@
 #include <string.h>
 
-#include "loader.h"
-#include "call.h"
+#include "../include/loader.h"
+#include "../include/call.h"
 #include "test.h"
 
 int main(int argc, char **argv)
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 
         call(func,
              "%f128 %f128 %f128",
-             0.1, 0.2, 0.3);
+             (long double)0.1, (long double)0.2, (long double)0.3);
 
     } else if (strcmp(argv[1], "test9") == 0) {
         func = load_function(handle, "test9");


### PR DESCRIPTION
Description:
Employs relative paths for convenience for IDEs. Corrects casting for cmake unit tests such that the compiler does not erroneously assume the float type in the case when long double is being tested.

To test:
1. Build as per normal.
2. ctest as per normal.
